### PR TITLE
Update XMLToPerlData.pm

### DIFF
--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm
@@ -113,7 +113,7 @@ sub parse_element{
 			}
 			
 			# Go up when finished
-			if( $self->node_depth <= $current_level ){
+			if( $self->node_depth <= $current_level or !ref( $sub_ref ) ){
 				###LogSD	$phone->talk( level => 'info', message => [
 				###LogSD		'Reached the end of node group at level: ' . ($current_level+1) ] );
 				last SUBNODES;


### PR DESCRIPTION
Reason: certain spreadsheet files resulted in endless loop

Solution: jump out of parse_element if sub_ref is no ref
